### PR TITLE
Fix deathlink

### DIFF
--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -1,20 +1,15 @@
 package gg.archipelago.aprandomizer.common;
 
 import gg.archipelago.aprandomizer.APRandomizer;
-import gg.archipelago.aprandomizer.common.Utils.Utils;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
-import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
-
-import java.util.ArrayList;
-import java.util.Set;
 
 public class DeathLinkDamage extends DamageSource {
 
@@ -28,27 +23,10 @@ public class DeathLinkDamage extends DamageSource {
 
     public static ResourceKey<DamageType> DEATH_LINK = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(APRandomizer.MODID,"death_link"));
 
-    private static class DamageTypeWrapper {
-        public Holder.Reference<DamageType> damageType;
-        DamageTypeWrapper() {
-            this.damageType = APRandomizer.getServer().registryAccess().lookupOrThrow(Registries.DAMAGE_TYPE).getOrThrow(DeathLinkDamage.DEATH_LINK);
-            // Don't know if this is explicitly needed considering the damage value, but it can't hurt.
-            this.damageType.bindTags(Set.of(
-                    DamageTypeTags.BYPASSES_INVULNERABILITY,
-                    DamageTypeTags.BYPASSES_COOLDOWN,
-                    DamageTypeTags.BYPASSES_RESISTANCE,
-                    DamageTypeTags.BYPASSES_ARMOR,
-                    DamageTypeTags.BYPASSES_EFFECTS,
-                    DamageTypeTags.BYPASSES_ENCHANTMENTS,
-                    DamageTypeTags.BYPASSES_SHIELD,
-                    DamageTypeTags.AVOIDS_GUARDIAN_THORNS
-            ));
-        }
-    }
-    private static final DamageTypeWrapper damageType = new DamageTypeWrapper();
+    private static final Holder<DamageType> damageType = APRandomizer.getServer().registryAccess().lookupOrThrow(Registries.DAMAGE_TYPE).getOrThrow(DeathLinkDamage.DEATH_LINK);
 
     public DeathLinkDamage() {
-        super(damageType.damageType);
+        super(damageType);
     }
 
     @Override

--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -1,15 +1,20 @@
 package gg.archipelago.aprandomizer.common;
 
 import gg.archipelago.aprandomizer.APRandomizer;
+import gg.archipelago.aprandomizer.common.Utils.Utils;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
+
+import java.util.ArrayList;
+import java.util.Set;
 
 public class DeathLinkDamage extends DamageSource {
 
@@ -23,10 +28,27 @@ public class DeathLinkDamage extends DamageSource {
 
     public static ResourceKey<DamageType> DEATH_LINK = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(APRandomizer.MODID,"death_link"));
 
-    private static final Holder<DamageType> damageType = APRandomizer.getServer().registryAccess().lookupOrThrow(Registries.DAMAGE_TYPE).getOrThrow(DeathLinkDamage.DEATH_LINK);
+    private static class DamageTypeWrapper {
+        public Holder.Reference<DamageType> damageType;
+        DamageTypeWrapper() {
+            this.damageType = APRandomizer.getServer().registryAccess().lookupOrThrow(Registries.DAMAGE_TYPE).getOrThrow(DeathLinkDamage.DEATH_LINK);
+            // Don't know if this is explicitly needed considering the damage value, but it can't hurt.
+            this.damageType.bindTags(Set.of(
+                    DamageTypeTags.BYPASSES_INVULNERABILITY,
+                    DamageTypeTags.BYPASSES_COOLDOWN,
+                    DamageTypeTags.BYPASSES_RESISTANCE,
+                    DamageTypeTags.BYPASSES_ARMOR,
+                    DamageTypeTags.BYPASSES_EFFECTS,
+                    DamageTypeTags.BYPASSES_ENCHANTMENTS,
+                    DamageTypeTags.BYPASSES_SHIELD,
+                    DamageTypeTags.AVOIDS_GUARDIAN_THORNS
+            ));
+        }
+    }
+    private static final DamageTypeWrapper damageType = new DamageTypeWrapper();
 
     public DeathLinkDamage() {
-        super(damageType);
+        super(damageType.damageType);
     }
 
     @Override

--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -31,6 +31,6 @@ public class DeathLinkDamage extends DamageSource {
 
     @Override
     public @NotNull Component getLocalizedDeathMessage(LivingEntity pLivingEntity) {
-        return Component.literal(pLivingEntity.getDisplayName().getString() +  "'s soul was linked to another's fate");
+        return Component.literal(pLivingEntity.getDisplayName().getString() +  "'s soul was linked to another's fate.");
     }
 }

--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -32,7 +32,7 @@ public class DeathLinkDamage extends DamageSource {
         public Holder.Reference<DamageType> damageType;
         DamageTypeWrapper() {
             this.damageType = APRandomizer.getServer().registryAccess().lookupOrThrow(Registries.DAMAGE_TYPE).getOrThrow(DeathLinkDamage.DEATH_LINK);
-            // Don't know if this is explicitly needed considering the damage value, but it can't hurt.
+            // Don't know if all of these are explicitly needed considering the damage value
             this.damageType.bindTags(Set.of(
                     DamageTypeTags.BYPASSES_INVULNERABILITY,
                     DamageTypeTags.BYPASSES_COOLDOWN,

--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -6,17 +6,47 @@ import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceKey;
 import net.minecraft.resources.ResourceLocation;
+import net.minecraft.tags.DamageTypeTags;
 import net.minecraft.world.damagesource.DamageSource;
 import net.minecraft.world.damagesource.DamageType;
 import net.minecraft.world.entity.LivingEntity;
 import org.jetbrains.annotations.NotNull;
 
+import java.util.ArrayList;
+import java.util.Set;
+
 public class DeathLinkDamage extends DamageSource {
 
+    /**
+     * Minecraft internally checks that the value is less than 3.4028235E37F,
+     * which is less than Float.MAX_VALUE.
+     * Decided to use a much lower value, in case Mojang decides to change it.
+     */
+    public static final float KILL_DAMAGE = 3.4028235E30F;
+
     public static ResourceKey<DamageType> DEATH_LINK = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(APRandomizer.MODID,"indirect_magic"));
-    private static final Holder<DamageType> damageType = APRandomizer.getServer().registryAccess().lookupOrThrow(Registries.DAMAGE_TYPE).getOrThrow(DeathLinkDamage.DEATH_LINK);
+
+    private static class DamageTypeWrapper {
+        public Holder.Reference<DamageType> damageType;
+        DamageTypeWrapper() {
+            this.damageType = APRandomizer.getServer().registryAccess().lookupOrThrow(Registries.DAMAGE_TYPE).getOrThrow(DeathLinkDamage.DEATH_LINK);
+            // Don't know if this is explicitly needed considering the damage value, but it can't hurt.
+            this.damageType.bindTags(Set.of(
+                    DamageTypeTags.BYPASSES_INVULNERABILITY,
+                    DamageTypeTags.BYPASSES_COOLDOWN,
+                    DamageTypeTags.BYPASSES_RESISTANCE,
+                    DamageTypeTags.BYPASSES_ARMOR,
+                    DamageTypeTags.BYPASSES_EFFECTS,
+                    DamageTypeTags.BYPASSES_ENCHANTMENTS,
+                    DamageTypeTags.BYPASSES_SHIELD,
+                    DamageTypeTags.AVOIDS_GUARDIAN_THORNS
+            ));
+        }
+    }
+    private static final DamageTypeWrapper damageType = new DamageTypeWrapper();
+
     public DeathLinkDamage() {
-        super(damageType);
+        super(damageType.damageType);
     }
 
     @Override

--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -1,6 +1,7 @@
 package gg.archipelago.aprandomizer.common;
 
 import gg.archipelago.aprandomizer.APRandomizer;
+import gg.archipelago.aprandomizer.common.Utils.Utils;
 import net.minecraft.core.Holder;
 import net.minecraft.core.registries.Registries;
 import net.minecraft.network.chat.Component;
@@ -25,7 +26,7 @@ public class DeathLinkDamage extends DamageSource {
      */
     public static final float KILL_DAMAGE = 3.4028235E20F;
 
-    public static ResourceKey<DamageType> DEATH_LINK = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(APRandomizer.MODID,"indirect_magic"));
+    public static ResourceKey<DamageType> DEATH_LINK = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(APRandomizer.MODID,"death_link"));
 
     private static class DamageTypeWrapper {
         public Holder.Reference<DamageType> damageType;
@@ -46,12 +47,15 @@ public class DeathLinkDamage extends DamageSource {
     }
     private static final DamageTypeWrapper damageType = new DamageTypeWrapper();
 
-    public DeathLinkDamage() {
+    private final String deathSource;
+
+    public DeathLinkDamage(String source) {
         super(damageType.damageType);
+        this.deathSource = source;
     }
 
     @Override
     public @NotNull Component getLocalizedDeathMessage(LivingEntity pLivingEntity) {
-        return Component.literal(pLivingEntity.getDisplayName().getString() +  "'s soul was linked to another's fate.");
+        return Component.literal(pLivingEntity.getDisplayName().getString() +  "'s soul was taken by " + deathSource);
     }
 }

--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -19,10 +19,11 @@ public class DeathLinkDamage extends DamageSource {
 
     /**
      * Minecraft internally checks that the value is less than 3.4028235E37F,
-     * which is less than Float.MAX_VALUE.
-     * Decided to use a much lower value, in case Mojang decides to change it.
+     * since they multiply it by 10 when awarding the stat to the player who dealt the damage.
+     * Just setting this to some large number in case the code is changed or if some multiplications
+     * occur before that guard is reached.
      */
-    public static final float KILL_DAMAGE = 3.4028235E30F;
+    public static final float KILL_DAMAGE = 3.4028235E20F;
 
     public static ResourceKey<DamageType> DEATH_LINK = ResourceKey.create(Registries.DAMAGE_TYPE, new ResourceLocation(APRandomizer.MODID,"indirect_magic"));
 

--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -47,15 +47,12 @@ public class DeathLinkDamage extends DamageSource {
     }
     private static final DamageTypeWrapper damageType = new DamageTypeWrapper();
 
-    private final String deathSource;
-
-    public DeathLinkDamage(String source) {
+    public DeathLinkDamage() {
         super(damageType.damageType);
-        this.deathSource = source;
     }
 
     @Override
     public @NotNull Component getLocalizedDeathMessage(LivingEntity pLivingEntity) {
-        return Component.literal(pLivingEntity.getDisplayName().getString() +  "'s soul was taken by " + deathSource);
+        return Component.literal(pLivingEntity.getDisplayName().getString() +  "'s soul was linked to another's fate");
     }
 }

--- a/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/DeathLinkDamage.java
@@ -15,7 +15,7 @@ public class DeathLinkDamage extends DamageSource {
 
     /**
      * Minecraft internally checks that the value is less than 3.4028235E37F,
-     * since they multiply it by 10 when awarding the stat to the player who dealt the damage.
+     * because they then multiply it by 10 for other stuff (e38 is the max value for a float).
      * Just setting this to some large number in case the code is changed or if some multiplications
      * occur before that guard is reached.
      */

--- a/src/main/java/gg/archipelago/aprandomizer/common/events/onDeath.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/events/onDeath.java
@@ -49,7 +49,7 @@ public class onDeath {
         deathMessages.set(false, server);
         for (ServerPlayer serverPlayer : APRandomizer.getServer().getPlayerList().getPlayers()) {
             if (serverPlayer != player) {
-                serverPlayer.hurt(new DeathLinkDamage(),Float.MAX_VALUE);
+                serverPlayer.hurt(new DeathLinkDamage(), DeathLinkDamage.KILL_DAMAGE);
             }
         }
         deathMessages.set(death, server);

--- a/src/main/java/gg/archipelago/aprandomizer/common/events/onDeath.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/events/onDeath.java
@@ -49,7 +49,7 @@ public class onDeath {
         deathMessages.set(false, server);
         for (ServerPlayer serverPlayer : APRandomizer.getServer().getPlayerList().getPlayers()) {
             if (serverPlayer != player) {
-                serverPlayer.hurt(new DeathLinkDamage(), DeathLinkDamage.KILL_DAMAGE);
+                serverPlayer.hurt(new DeathLinkDamage(event.getEntity().getDisplayName().getString()), DeathLinkDamage.KILL_DAMAGE);
             }
         }
         deathMessages.set(death, server);

--- a/src/main/java/gg/archipelago/aprandomizer/common/events/onDeath.java
+++ b/src/main/java/gg/archipelago/aprandomizer/common/events/onDeath.java
@@ -49,7 +49,7 @@ public class onDeath {
         deathMessages.set(false, server);
         for (ServerPlayer serverPlayer : APRandomizer.getServer().getPlayerList().getPlayers()) {
             if (serverPlayer != player) {
-                serverPlayer.hurt(new DeathLinkDamage(event.getEntity().getDisplayName().getString()), DeathLinkDamage.KILL_DAMAGE);
+                serverPlayer.hurt(new DeathLinkDamage(), DeathLinkDamage.KILL_DAMAGE);
             }
         }
         deathMessages.set(death, server);

--- a/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
+++ b/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
@@ -40,7 +40,7 @@ public class onDeathLink {
             }
             showDeathMessages.set(false,APRandomizer.getServer());
             for (ServerPlayer player : APRandomizer.getServer().getPlayerList().getPlayers()) {
-                player.hurt(new DeathLinkDamage() , Float.MAX_VALUE);
+                player.hurt(new DeathLinkDamage() , DeathLinkDamage.KILL_DAMAGE);
             }
             showDeathMessages.set(showDeaths,APRandomizer.getServer());
         }

--- a/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
+++ b/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
@@ -21,7 +21,7 @@ public class onDeathLink {
             if(!showDeaths) {
                 String cause = event.cause;
                 if(cause != null && !cause.isBlank())
-                    Utils.sendMessageToAll(event.cause);
+                    Utils.sendMessageToAll(cause);
                 else
                     Utils.sendMessageToAll("This Death brought to you by " + event.source);
             }

--- a/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
+++ b/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
@@ -16,17 +16,13 @@ public class onDeathLink {
             if(event.time == APRandomizer.getLastDeathTimestamp())
                 return;
 
-            GameRules.BooleanValue showDeathMessages = APRandomizer.getServer().getGameRules().getRule(GameRules.RULE_SHOWDEATHMESSAGES);
-            boolean showDeaths = showDeathMessages.get();
-            if(!showDeaths) {
-                String cause = event.cause;
-                if(cause != null && !cause.isBlank())
-                    Utils.sendMessageToAll(event.cause);
-                else
-                    Utils.sendMessageToAll("This Death brought to you by " + event.source);
-            }
+            String cause = event.cause;
+            if(cause != null && !cause.isBlank())
+                Utils.sendMessageToAll(event.cause);
+            else
+                Utils.sendMessageToAll("This Death brought to you by " + event.source);
             for (ServerPlayer player : APRandomizer.getServer().getPlayerList().getPlayers()) {
-                player.hurt(new DeathLinkDamage(event.source), DeathLinkDamage.KILL_DAMAGE);
+                player.hurt(new DeathLinkDamage(), DeathLinkDamage.KILL_DAMAGE);
             }
         }
     }

--- a/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
+++ b/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
@@ -19,9 +19,8 @@ public class onDeathLink {
             GameRules.BooleanValue showDeathMessages = APRandomizer.getServer().getGameRules().getRule(GameRules.RULE_SHOWDEATHMESSAGES);
             boolean showDeaths = showDeathMessages.get();
             if(!showDeaths) {
-                String cause = event.cause;
-                if(cause != null && !cause.isBlank())
-                    Utils.sendMessageToAll(cause);
+                if(event.cause != null && !event.cause.isBlank())
+                    Utils.sendMessageToAll(event.cause);
                 else
                     Utils.sendMessageToAll("This Death brought to you by " + event.source);
             }

--- a/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
+++ b/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
@@ -1,42 +1,29 @@
 package gg.archipelago.aprandomizer.events;
 
-import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import gg.archipelago.aprandomizer.APRandomizer;
 import gg.archipelago.aprandomizer.common.DeathLinkDamage;
 import gg.archipelago.aprandomizer.common.Utils.Utils;
 import gg.archipelago.client.events.ArchipelagoEventListener;
-import gg.archipelago.client.events.BouncedEvent;
-import net.minecraft.core.Holder;
-import net.minecraft.core.registries.Registries;
-import net.minecraft.nbt.CompoundTag;
-import net.minecraft.nbt.TagParser;
-import net.minecraft.resources.ResourceKey;
+import gg.archipelago.client.events.DeathLinkEvent;
 import net.minecraft.server.level.ServerPlayer;
-import net.minecraft.world.damagesource.DamageType;
-import net.minecraft.world.entity.Entity;
-import net.minecraft.world.entity.EntityType;
-import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.level.GameRules;
-import net.minecraft.world.phys.Vec3;
-
-import java.util.concurrent.ThreadLocalRandom;
 
 public class onDeathLink {
 
     @ArchipelagoEventListener
-    public static void onBounce(BouncedEvent event) {
-        if(event.tags.contains("DeathLink") && APRandomizer.getAP().getSlotData().deathlink) {
-            if(event.getDouble("time") == APRandomizer.getLastDeathTimestamp())
+    public static void onDeathLink(DeathLinkEvent event) {
+        if(APRandomizer.getAP().getSlotData().deathlink) {
+            if(event.time == APRandomizer.getLastDeathTimestamp())
                 return;
 
             GameRules.BooleanValue showDeathMessages = APRandomizer.getServer().getGameRules().getRule(GameRules.RULE_SHOWDEATHMESSAGES);
             boolean showDeaths = showDeathMessages.get();
             if(showDeaths) {
-                String cause = event.getString("cause");
+                String cause = event.cause;
                 if(cause != null && !cause.isBlank())
-                    Utils.sendMessageToAll(event.getString("cause"));
+                    Utils.sendMessageToAll(event.cause);
                 else
-                    Utils.sendMessageToAll("This Death brought to you by "+ event.getString("source"));
+                    Utils.sendMessageToAll("This Death brought to you by "+ event.source);
             }
             showDeathMessages.set(false,APRandomizer.getServer());
             for (ServerPlayer player : APRandomizer.getServer().getPlayerList().getPlayers()) {

--- a/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
+++ b/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
@@ -18,18 +18,16 @@ public class onDeathLink {
 
             GameRules.BooleanValue showDeathMessages = APRandomizer.getServer().getGameRules().getRule(GameRules.RULE_SHOWDEATHMESSAGES);
             boolean showDeaths = showDeathMessages.get();
-            if(showDeaths) {
+            if(!showDeaths) {
                 String cause = event.cause;
                 if(cause != null && !cause.isBlank())
                     Utils.sendMessageToAll(event.cause);
                 else
-                    Utils.sendMessageToAll("This Death brought to you by "+ event.source);
+                    Utils.sendMessageToAll("This Death brought to you by " + event.source);
             }
-            showDeathMessages.set(false,APRandomizer.getServer());
             for (ServerPlayer player : APRandomizer.getServer().getPlayerList().getPlayers()) {
-                player.hurt(new DeathLinkDamage() , DeathLinkDamage.KILL_DAMAGE);
+                player.hurt(new DeathLinkDamage(event.source), DeathLinkDamage.KILL_DAMAGE);
             }
-            showDeathMessages.set(showDeaths,APRandomizer.getServer());
         }
     }
 }

--- a/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
+++ b/src/main/java/gg/archipelago/aprandomizer/events/onDeathLink.java
@@ -16,14 +16,20 @@ public class onDeathLink {
             if(event.time == APRandomizer.getLastDeathTimestamp())
                 return;
 
-            String cause = event.cause;
-            if(cause != null && !cause.isBlank())
-                Utils.sendMessageToAll(event.cause);
-            else
-                Utils.sendMessageToAll("This Death brought to you by " + event.source);
+            GameRules.BooleanValue showDeathMessages = APRandomizer.getServer().getGameRules().getRule(GameRules.RULE_SHOWDEATHMESSAGES);
+            boolean showDeaths = showDeathMessages.get();
+            if(!showDeaths) {
+                String cause = event.cause;
+                if(cause != null && !cause.isBlank())
+                    Utils.sendMessageToAll(event.cause);
+                else
+                    Utils.sendMessageToAll("This Death brought to you by " + event.source);
+            }
+            showDeathMessages.set(false, APRandomizer.getServer());
             for (ServerPlayer player : APRandomizer.getServer().getPlayerList().getPlayers()) {
                 player.hurt(new DeathLinkDamage(), DeathLinkDamage.KILL_DAMAGE);
             }
+            showDeathMessages.set(showDeaths, APRandomizer.getServer());
         }
     }
 }


### PR DESCRIPTION
- Lower damage amount. Had a peek into the minecraft forge code and noticed a guard that prevented the damage from occurring.
- Updated the `onDeathLink` event to use the correct event structure.
    - I'm not set on my change regarding the death messages. I only removed that code since turning off the game rule was preventing the custom message from `DeathLinkDamage` from showing. I don't know what the intended result was for the code, so some clarification one that would be swell.
- Fixed where the `DEATH_LINK` damage type resource was being pulled from.